### PR TITLE
closed the scanner to avoid resource leak

### DIFF
--- a/Java/Coin Change.java
+++ b/Java/Coin Change.java
@@ -14,7 +14,7 @@ public class Main {
             
         int target = scn.nextInt();
         System.out.println(coinchange(arr,target));
-        
+        scn.close();  
     }
     
     


### PR DESCRIPTION
I added a line scr.close() that closes the scanner to avoid a resource leak.